### PR TITLE
Fixes for Arch ARM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ endif(BUILD_DOC)
 
 # Debug/Release flags
 set(CMAKE_C_FLAGS_DEBUG "-DGRFUTILS_DEBUG")
+set (CMAKE_SHARED_LINKER_FLAGS "-lrt")
 
 # Compiler flags
 add_definitions("-Wall")

--- a/COMPILE
+++ b/COMPILE
@@ -1,12 +1,17 @@
+
+Short overview for those who don't read manuals. This COMPILE file describes
+how to compile and setup libgrf.so and grfctl
+
 == Installation
 
 Clone this repository:
-# git clone git://github.com/pldemone/grfutils
+# git clone git://github.com/DocLambda/grfutils
 # cd grfutils
 
 == Linux and FreeBSD
 
-Make sure you have cmake and the gcc toolchain required for compilation installed:
+Make sure you have cmake and the gcc toolchain required for compilation
+installed:
 
 * Ubuntu
 # sudo apt-get install build-essential cmake

--- a/COMPILE
+++ b/COMPILE
@@ -1,0 +1,43 @@
+== Installation
+
+Clone this repository:
+# git clone git://github.com/pldemone/grfutils
+# cd grfutils
+
+== Linux and FreeBSD
+
+Make sure you have cmake and the gcc toolchain required for compilation installed:
+
+* Ubuntu
+# sudo apt-get install build-essential cmake
+
+* Fedora
+# sudo yum install make cmake gcc gcc-c++
+
+* FreeBSD
+# pkg install cmake
+
+Build:
+# cd grfutils
+# cmake .
+# make
+
+== Raspberry/Raspbian
+
+Download and install the latest Raspbian development distribution.
+
+Set environment:
+# mkdir rtools
+# cd rtools
+# git clone git://github.com/raspberrypi/tools.git
+# export RASPBIANSRC=PATH_TO_rtools
+# export PATH=${RASPBIANSRC}/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin:$PATH
+# export CXX=${RASPBIANSRC}/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/g++
+# export CC=${RASPBIANSRC}/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/gcc
+
+Build:
+# cd grfutils
+# cmake .
+# make
+
+

--- a/bin/grfctl.c
+++ b/bin/grfctl.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
 	int            loglevel = GRF_DEFAULT_LOGLEVEL;
 	int            index;
 	int            ret;
-	char           c;
+	int            c;
 
 	static struct option options[] =
 	{

--- a/src/grf_radio_uart.c
+++ b/src/grf_radio_uart.c
@@ -433,9 +433,9 @@ int grf_radio_write(struct grf_radio *radio, const char *message, size_t len)
 		len     -= count;
 	}
 
-	if (fsync(radio->fd))
+	if (tcflush(radio->fd, TCOFLUSH))
 	{
-		grf_logging_err("Calling fsync on %d failed: %s", radio->fd, strerror(errno));
+		grf_logging_err("Calling tcflush on %d failed: %s", radio->fd, strerror(errno));
 		return errno;
 	}
 
@@ -450,9 +450,9 @@ int grf_radio_write_ctrl(struct grf_radio *radio, char ctrl)
 	if (write(radio->fd, &ctrl, sizeof(char)) < 0)
 		return errno;
 
-	if (fsync(radio->fd))
+	if (tcflush(radio->fd, TCOFLUSH))
 	{
-		grf_logging_err("Calling fsync on %d failed: %s", radio->fd, strerror(errno));
+		grf_logging_err("Calling tcflush on %d failed: %s", radio->fd, strerror(errno));
 		return errno;
 	}
 


### PR DESCRIPTION
Small fixes for Arch ARM and documenation changes
- Use tcflush() instead fsync() for data synchronization
- Set correct return type for getopt_long()
- "-lrt" shared linker flags added to CMakeLists.txt
- Short compile/cross-compile description added
